### PR TITLE
Add invalid email format rejection test

### DIFF
--- a/tests/invalid_email_format.robot
+++ b/tests/invalid_email_format.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Library  SeleniumLibrary
+
+*** Test Cases ***
+Invalid Email Format Test
+    [Documentation]  Verify system rejects invalid email formats and displays appropriate error message.
+    Input Valid Data Except Email
+    Input Invalid Email
+    Click Save Button
+    Verify Error Message
+
+*** Keywords ***
+Input Valid Data Except Email
+    Input Text  id=name  Valid Name
+    Input Text  id=phone  1234567890
+    Input Text  id=company  Valid Company
+    Input Text  id=position  Valid Position
+
+Input Invalid Email
+    Input Text  id=email  invalidemail.com
+
+Click Save Button
+    Click Button  id=save
+
+Verify Error Message
+    Element Should Contain  id=email-error  Invalid email format


### PR DESCRIPTION
This pull request adds a test case to verify that the system rejects invalid email formats and displays an appropriate error message. The test covers entering valid data in all fields except for the email, where an invalid format is used.